### PR TITLE
fixed bug where list was not loading on initial click

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -4,7 +4,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         if (request.payload) {
             request.payload.forEach(link => {
                 addEntry(link.title, link.copyText)
-            })
+            })   
         }
     } else if (request.message === "insert_success") {
         if (request.payload) {
@@ -16,6 +16,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         }
     } else if (request.message === "delete_success") {
         if (request.payload) {
+
             // Remove linkGroup from DOM
             recordToDelete.remove()
         }


### PR DESCRIPTION
Added logic to fetch all records once db is created and opened, inside of create_database(). This is in addition to the request made when the get_all_records message is sent from popup.js.

This is useful for when the service worker is inactive because when the extension UI is opened, the request to get all records is automatically sent. It won't work however because when the service worker is coming out of its inactive state, the db has to be created and opened again. If the UI is opened when the service worker is inactive, the db has not yet been created the and request won't work. But adding the request inside of create_database() enables the records to be fetched after the db has been setup.